### PR TITLE
Update Lulesh-2.0 for Kokkos v3.0 promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ There are more Kokkos versions of miniApps on github in the following repositori
 * MiniAero, a unstructured finite elements (more complex than MiniFE): https://github.com/Mantevo/miniAero
 * Snap, discrete ordinates neutral particle transport: https://github.com/UoB-HPC/SNAP-Kokkos
 * TeaLeaf, heat conduction unassembled solve: https://github.com/UoB-HPC/TeaLeaf-Kokkos
-* HPCG, MultiGrid Preconditioned Conjugat Gradient Solve, part ot Top500 benchmarks: https://github.com/kokkos/hpcg
+* KHPCG, MultiGrid Preconditioned Conjugate Gradient Solve, part ot Top500 benchmarks: https://github.com/hpcg-benchmark/KHPCG3.0
 

--- a/lulesh-2.0/kokkos-minimal-cpu/Makefile
+++ b/lulesh-2.0/kokkos-minimal-cpu/Makefile
@@ -1,7 +1,7 @@
 #Set your Kokkos path to something appropriate
 KOKKOS_PATH = ${HOME}/kokkos
 KOKKOS_DEVICES = "Serial"
-KOKKOS_ARCH = 
+KOKKOS_ARCH = "SNB"
 
 SRC = $(wildcard *.cc)
 

--- a/lulesh-2.0/kokkos-optimized/Makefile
+++ b/lulesh-2.0/kokkos-optimized/Makefile
@@ -1,5 +1,5 @@
 #Set your Kokkos path to something appropriate
-KOKKOS_PATH = $(HOME)kokkos
+KOKKOS_PATH = $(HOME)/kokkos
 KOKKOS_DEVICES = "Serial"
 KOKKOS_ARCH = "SNB"
 


### PR DESCRIPTION
This pull request is to update lulesh-2.0 for the Kokkos version 3.0 promotion. There were however, no problems with this mini-app when deprecated code was disabled (KOKKOS_OPTIONS=disable_deprecated_code). Lulesh-2.0 works as is, with support for deprecated code disabled or enabled (the default). Simply made minor updates to the existing Makefiles.

This pull request corresponds to issue #1

There will be a complete removal of deprecated code support after the Kokkos version 3.0 release, hence the intention of this pull request. Current status and timeline for Kokkos code deprecations is at: https://github.com/kokkos/kokkos/wiki/DeprecationPage.

Lulesh-2.0 should work out of the box with Kokkos versions 2.9 (current) and 3.0 (upcoming), but please let me know if you have any problems with the 3.0 release.
